### PR TITLE
[semver:minor] Change to CIRCLE_OIDC_TOKEN_V2

### DIFF
--- a/src/scripts/assume_role.sh
+++ b/src/scripts/assume_role.sh
@@ -3,7 +3,7 @@ PARAM_ROLE_ARN=$(eval echo "\$$PARAM_ROLE_ARN")
 # SEE: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/assume-role-with-web-identity.html
 credentials=$(aws sts assume-role-with-web-identity \
   --role-arn "${PARAM_ROLE_ARN}" \
-  --web-identity-token "${CIRCLE_OIDC_TOKEN}" \
+  --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
   --role-session-name "CircleCI" \
   --duration-seconds "${PARAM_DURATION_SECOND}" \
   --query "Credentials" \


### PR DESCRIPTION
To use a new format for the `sub` claim
https://circleci.com/docs/openid-connect-tokens/